### PR TITLE
Explicit strict_supports in tests

### DIFF
--- a/tests/test_octodns_provider_hetzner.py
+++ b/tests/test_octodns_provider_hetzner.py
@@ -88,7 +88,7 @@ class TestHetznerProvider(TestCase):
         del provider._zone_records[zone.name]
 
     def test_apply(self):
-        provider = HetznerProvider('test', 'token')
+        provider = HetznerProvider('test', 'token', strict_supports=False)
 
         resp = Mock()
         resp.json = Mock()


### PR DESCRIPTION
As of https://github.com/octodns/octodns/pull/957 we'll need t be explicit in our tests around the expectations of `Provider.strict_supports`. This PR is in preparation of that change. 

/cc https://github.com/octodns/octodns/pull/957