### PR TITLE
Ignore octoDNS 2.0 deprecation warnings

### DIFF
--- a/.changelog/921be98998af407c8cc6227e7441ec65.md
+++ b/.changelog/921be98998af407c8cc6227e7441ec65.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Ignore octoDNS 2.0 deprecation warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ sections="FUTURE,STDLIB,THIRDPARTY,OCTODNS,FIRSTPARTY,LOCALFOLDER"
 [tool.pytest.ini_options]
 filterwarnings = [
     'error',
+    'ignore:.*DEPRECATED.*2.0',
 ]
 pythonpath = "."
 


### PR DESCRIPTION
Ignore deprecation warnings for APIs scheduled for removal in octoDNS 2.0 while retaining warning-as-error behavior for all other warnings.

These warnings will be addressed when this module migrates to the octoDNS 2.x APIs.

/cc octodns/octodns#1452 Validate downstream compatibility for the RDATA API migration