### PR TITLE
Migrate to octoDNS's new RDATA API

### DIFF
--- a/.changelog/007692a346224a389e7a6ce943212df3.md
+++ b/.changelog/007692a346224a389e7a6ce943212df3.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Migrate to octoDNS's new RDATA API (`Rrset`/`from_rdata_text`/`to_rdata_text`), replacing the deprecated `parse_rdata_text`/`rdata_text` calls. Requires `octodns>=1.22.0`. `populate()` now groups API records into `Rrset`s and parses them via `Record.from_rrsets()`, and record serialization for `_apply()` is a single generic `_params_for()` built from `record.to_rrset()`, replacing eleven `_data_for_*`/ten `_params_for_*` methods. TXT keeps dedicated handling on both sides since Hetzner's dnsapi uses raw provider text rather than RDATA presentation format. Fixes a bug where multi-value PTR records only kept their first value.

--- a/.changelog/921be98998af407c8cc6227e7441ec65.md
+++ b/.changelog/921be98998af407c8cc6227e7441ec65.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Ignore octoDNS 2.0 deprecation warnings

--- a/octodns_hetzner/__init__.py
+++ b/octodns_hetzner/__init__.py
@@ -6,11 +6,15 @@ import logging
 from collections import defaultdict
 
 from octodns.provider.base import BaseProvider
-from octodns.record import Record
+from octodns.record import RdataParseError, Record, Rrset
 from octodns.record.caa import CaaValue
-from octodns.record.ds import DsValue
-from octodns.record.rr import RrParseError
-from octodns.record.tlsa import TlsaValue
+
+# There is no public export for the TXT/SPF value type; this is the same
+# private class octoDNS core's own tinydns source uses for the equivalent
+# raw-text handling (octodns/source/tinydns.py). Flagged upstream on
+# octodns/octodns#1452 as a gap: providers that receive raw (non-RDATA)
+# TXT/SPF text have no public class to call normalize_raw_text() on.
+from octodns.record.chunked import _ChunkedValue as TxtValue
 
 # Import exceptions for backward compatibility
 from .exceptions import (
@@ -158,128 +162,33 @@ class HetznerProvider(BaseProvider):
         default_ttl = self.zone_metadata(zone_id=record["zone_id"])["ttl"]
         return record["ttl"] if "ttl" in record else default_ttl
 
-    def _data_for_multiple(self, _type, records):
-        values = [record["value"].replace(";", "\\;") for record in records]
-        return {
-            "ttl": self._record_ttl(records[0]),
-            "type": _type,
-            "values": values,
-        }
+    def _rdata_for(self, _type, value):
+        """Normalize a raw Hetzner API value into RDATA presentation text.
 
-    _data_for_A = _data_for_multiple
-    _data_for_AAAA = _data_for_multiple
-
-    def _data_for_CAA(self, _type, records):
-        values = []
-        for record in records:
-            raw = record["value"]
+        Hetzner returns values with the record-name-shaped fields (targets,
+        exchanges) missing their trailing dot, so that gets patched in here,
+        before handing the string to octoDNS's from_rdata_text() parsers.
+        """
+        if _type in ("CNAME", "NS", "PTR"):
+            return self._append_dot(value)
+        elif _type in ("MX", "SRV"):
+            # only the trailing field (target/exchange) is a name
+            head, _, target = value.strip().rpartition(" ")
+            return f"{head} {self._append_dot(target)}"
+        elif _type == "CAA":
             try:
-                parsed = CaaValue.parse_rdata_text(raw)
-                values.append(parsed)
-            except RrParseError as e:
-                # Fallback best-effort for unexpected formats
+                CaaValue.from_rdata_text(value)
+            except RdataParseError as e:
+                # Fallback best-effort for unexpected formats, matches the
+                # previous behavior of _data_for_CAA
                 self.log.warning(
-                    "_data_for_CAA: failed to parse CAA record %r: %s, "
-                    "using fallback values (flags=0, tag=issue)",
-                    raw,
+                    "_rdata_for: failed to parse CAA record %r: %s, "
+                    "using fallback value (flags=0, tag=issue)",
+                    value,
                     e,
                 )
-                values.append({"flags": 0, "tag": "issue", "value": raw})
-        return {
-            "ttl": self._record_ttl(records[0]),
-            "type": _type,
-            "values": values,
-        }
-
-    def _data_for_CNAME(self, _type, records):
-        record = records[0]
-        return {
-            "ttl": self._record_ttl(record),
-            "type": _type,
-            "value": self._append_dot(record["value"]),
-        }
-
-    def _data_for_PTR(self, _type, records):
-        record = records[0]
-        return {
-            "ttl": self._record_ttl(record),
-            "type": _type,
-            "value": self._append_dot(record["value"]),
-        }
-
-    def _data_for_MX(self, _type, records):
-        values = []
-        for record in records:
-            value_stripped_split = record["value"].strip().split(" ")
-            preference = value_stripped_split[0]
-            exchange = value_stripped_split[-1]
-            values.append(
-                {
-                    "preference": int(preference),
-                    "exchange": self._append_dot(exchange),
-                }
-            )
-        return {
-            "ttl": self._record_ttl(records[0]),
-            "type": _type,
-            "values": values,
-        }
-
-    def _data_for_NS(self, _type, records):
-        values = []
-        for record in records:
-            values.append(self._append_dot(record["value"]))
-        return {
-            "ttl": self._record_ttl(records[0]),
-            "type": _type,
-            "values": values,
-        }
-
-    def _data_for_DS(self, _type, records):
-        values = []
-        for record in records:
-            parsed = DsValue.parse_rdata_text(record["value"])
-            values.append(parsed)
-        return {
-            "ttl": self._record_ttl(records[0]),
-            "type": _type,
-            "values": values,
-        }
-
-    def _data_for_SRV(self, _type, records):
-        values = []
-        for record in records:
-            value_stripped = record["value"].strip()
-            priority = value_stripped.split(" ")[0]
-            weight = value_stripped[len(priority) :].strip().split(" ")[0]
-            target = value_stripped.split(" ")[-1]
-            port = value_stripped[: -len(target)].strip().split(" ")[-1]
-            values.append(
-                {
-                    "port": int(port),
-                    "priority": int(priority),
-                    "target": self._append_dot(target),
-                    "weight": int(weight),
-                }
-            )
-        return {
-            "ttl": self._record_ttl(records[0]),
-            "type": _type,
-            "values": values,
-        }
-
-    _data_for_TXT = _data_for_multiple
-
-    def _data_for_TLSA(self, _type, records):
-        values = []
-        for record in records:
-            parsed = TlsaValue.parse_rdata_text(record["value"])
-            values.append(parsed)
-        return {
-            "ttl": self._record_ttl(records[0]),
-            "type": _type,
-            "values": values,
-        }
+                return f'0 issue "{value}"'
+        return value
 
     def list_zones(self):
         self.log.debug("list_zones:")
@@ -324,17 +233,57 @@ class HetznerProvider(BaseProvider):
             values[record["name"]][record["type"]].append(record)
 
         before = len(zone.records)
+        rrsets = []
         for name, types in values.items():
+            fqdn = zone.name if name == "@" else f"{name}.{zone.name}"
             for _type, records in types.items():
-                data_for = getattr(self, f"_data_for_{_type}")
-                record = Record.new(
-                    zone,
-                    name,
-                    data_for(_type, records),
-                    source=self,
-                    lenient=lenient,
-                )
-                zone.add_record(record, lenient=lenient)
+                ttl = self._record_ttl(records[0])
+                if _type == "TXT":
+                    # Hetzner returns TXT as raw provider text, not RDATA
+                    # presentation format, so these can't go through
+                    # Record.from_rrsets() -> TxtValue.from_rdata_text().
+                    # dnspython treats an unquoted ';' as a master-file
+                    # comment, which silently truncates values like
+                    # 'v=DKIM1;k=rsa;s=email;...' down to 'v=DKIM1', and
+                    # raises RdataParseError on any unquoted value over 255
+                    # chars.
+                    #
+                    # The quoting we get back is inconsistent (see
+                    # ansible-collections/community.dns#48): values over 255
+                    # bytes come back as multiple quoted chunks, while
+                    # shorter values without spaces keep whatever quoting was
+                    # originally written. normalize_raw_text() handles both
+                    # -- TxtValue.process() strips the outer quotes and joins
+                    # on '" "'.
+                    data = {
+                        "ttl": ttl,
+                        "type": _type,
+                        "values": [
+                            TxtValue.normalize_raw_text(record["value"])
+                            for record in records
+                        ],
+                    }
+                    new_record = Record.new(
+                        zone, name, data, source=self, lenient=lenient
+                    )
+                    zone.add_record(new_record, lenient=lenient)
+                else:
+                    rrsets.append(
+                        Rrset(
+                            fqdn,
+                            _type,
+                            ttl,
+                            [
+                                self._rdata_for(_type, record["value"])
+                                for record in records
+                            ],
+                        )
+                    )
+
+        for record in Record.from_rrsets(
+            zone, rrsets, lenient=lenient, source=self
+        ):
+            zone.add_record(record, lenient=lenient)
 
         exists = zone.name in self._zone_records
         self.log.info(
@@ -344,129 +293,51 @@ class HetznerProvider(BaseProvider):
         )
         return exists
 
-    def _params_for_multiple(self, record):
-        for value in record.values:
-            yield {
-                "value": value.replace("\\;", ";"),
-                "name": record.name,
-                "ttl": record.ttl,
-                "type": record._type,
-            }
-
-    _params_for_A = _params_for_multiple
-    _params_for_AAAA = _params_for_multiple
-
-    def _params_for_CAA(self, record):
-        for value in record.values:
-            data = f'{value.flags} {value.tag} "{value.value}"'
-            yield {
-                "value": data,
-                "name": record.name,
-                "ttl": record.ttl,
-                "type": record._type,
-            }
-
-    def _params_for_single(self, record):
-        yield {
-            "value": record.value,
-            "name": record.name,
-            "ttl": record.ttl,
-            "type": record._type,
-        }
-
-    _params_for_CNAME = _params_for_single
-    _params_for_PTR = _params_for_single
-
-    def _params_for_MX(self, record):
-        for value in record.values:
-            data = f"{value.preference} {value.exchange}"
-            yield {
-                "value": data,
-                "name": record.name,
-                "ttl": record.ttl,
-                "type": record._type,
-            }
-
-    _params_for_NS = _params_for_multiple
-
-    def _params_for_DS(self, record):
-        for value in record.values:
-            data = f"{value.key_tag} {value.algorithm} {value.digest_type} {value.digest}"
-            yield {
-                "value": data,
-                "name": record.name,
-                "ttl": record.ttl,
-                "type": record._type,
-            }
-
-    def _params_for_SRV(self, record):
-        for value in record.values:
-            data = (
-                f"{value.priority} {value.weight} {value.port} {value.target}"
-            )
-            yield {
-                "value": data,
-                "name": record.name,
-                "ttl": record.ttl,
-                "type": record._type,
-            }
-
-    def _params_for_TXT(self, record):
-        """Generate params for TXT records.
-
-        For hcloud backend: Uses record.chunked_values which automatically
-        splits values >255 chars into RFC-compliant chunks with proper quoting.
-
-        For dnsapi backend: Uses record.values (raw values) as the API
-        handles formatting internally.
-
-        This ensures long TXT values (e.g., DKIM keys) work correctly
-        with the hcloud backend while maintaining compatibility with dnsapi.
-        """
-        if self._backend == "hcloud":
-            # Use chunked_values for proper RFC-compliant chunking
-            # Returns pre-quoted format: '"chunk1" "chunk2"'
-            for value in record.chunked_values:
-                yield {
-                    "value": value.replace("\\;", ";"),
-                    "name": record.name,
-                    "ttl": record.ttl,
-                    "type": record._type,
-                }
+    def _params_for(self, record):
+        rrset = record.to_rrset()
+        if record._type == "TXT" and self._backend != "hcloud":
+            # dnsapi wants raw text rather than the presentation-format
+            # RDATA to_rrset() produces. It would accept quoted values, but
+            # writing them is a bad trade: Hetzner's re-quoting is
+            # inconsistent enough to cause idempotency churn (see
+            # ansible-collections/community.dns#48, which settled on
+            # unquoted-by-default for Hetzner over exactly this),
+            # to_rdata_text() escapes '"' as '\"' which TxtValue.process()
+            # never unescapes on the way back in, and Hetzner already chunks
+            # long raw values RFC-conformantly on its own side.
+            #
+            # octoDNS core has normalize_raw_text() for presentation ->
+            # internal on read but no inverse for internal -> raw, so
+            # unescape by hand.
+            rdatas = [value.replace("\\;", ";") for value in record.values]
         else:
-            # dnsapi backend: use raw values
-            for value in record.values:
-                yield {
-                    "value": value.replace("\\;", ";"),
-                    "name": record.name,
-                    "ttl": record.ttl,
-                    "type": record._type,
-                }
-
-    def _params_for_TLSA(self, record):
-        for value in record.values:
-            data = (
-                f"{value.certificate_usage} {value.selector} {value.matching_type} "
-                f"{value.certificate_association_data}"
-            )
+            # hcloud is RRSet-native and wants quoted, chunked presentation
+            # text -- exactly what to_rrset() emits, matching the
+            # record.chunked_values output this replaces.
+            rdatas = rrset.rdatas
+        for rdata in rdatas:
             yield {
-                "value": data,
+                "value": rdata,
                 "name": record.name,
-                "ttl": record.ttl,
-                "type": record._type,
+                "ttl": rrset.ttl,
+                "type": rrset._type,
             }
 
     def _apply_Create(self, zone_id, change):
         """Delegate create operation to strategy."""
-        params_for = getattr(self, f"_params_for_{change.new._type}")
-        self._strategy.apply_create(self._client, zone_id, change, params_for)
+        self._strategy.apply_create(
+            self._client, zone_id, change, self._params_for
+        )
 
     def _apply_Update(self, zone_id, change):
         """Delegate update operation to strategy."""
-        params_for = getattr(self, f"_params_for_{change.new._type}")
         zone = change.existing.zone
         self._strategy.apply_update(
-            self._client, zone_id, change, params_for, self.zone_records(zone)
+            self._client,
+            zone_id,
+            change,
+            self._params_for,
+            self.zone_records(zone),
         )
 
     def _apply_Delete(self, zone_id, change):

--- a/octodns_hetzner/__init__.py
+++ b/octodns_hetzner/__init__.py
@@ -6,15 +6,8 @@ import logging
 from collections import defaultdict
 
 from octodns.provider.base import BaseProvider
-from octodns.record import RdataParseError, Record, Rrset
+from octodns.record import RdataParseError, Record, Rrset, TxtValue
 from octodns.record.caa import CaaValue
-
-# There is no public export for the TXT/SPF value type; this is the same
-# private class octoDNS core's own tinydns source uses for the equivalent
-# raw-text handling (octodns/source/tinydns.py). Flagged upstream on
-# octodns/octodns#1452 as a gap: providers that receive raw (non-RDATA)
-# TXT/SPF text have no public class to call normalize_raw_text() on.
-from octodns.record.chunked import _ChunkedValue as TxtValue
 
 # Import exceptions for backward compatibility
 from .exceptions import (

--- a/octodns_hetzner/__init__.py
+++ b/octodns_hetzner/__init__.py
@@ -298,11 +298,7 @@ class HetznerProvider(BaseProvider):
             # to_rdata_text() escapes '"' as '\"' which TxtValue.process()
             # never unescapes on the way back in, and Hetzner already chunks
             # long raw values RFC-conformantly on its own side.
-            #
-            # octoDNS core has normalize_raw_text() for presentation ->
-            # internal on read but no inverse for internal -> raw, so
-            # unescape by hand.
-            rdatas = [value.replace("\\;", ";") for value in record.values]
+            rdatas = [value.to_raw_text() for value in record.values]
         else:
             # hcloud is RRSet-native and wants quoted, chunked presentation
             # text -- exactly what to_rrset() emits, matching the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "octodns>=1.5.0",
+    "octodns>=1.22.0",
     "requests>=2.27.0",
     "hcloud>=2.3.0",
 ]
@@ -85,7 +85,6 @@ sections="FUTURE,STDLIB,THIRDPARTY,OCTODNS,FIRSTPARTY,LOCALFOLDER"
 [tool.pytest.ini_options]
 filterwarnings = [
     'error',
-    'ignore:.*DEPRECATED.*2.0',
 ]
 pythonpath = "."
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,11 @@ msgpack==1.2.1
 mypy-extensions==1.1.0
 natsort==8.4.0
 nh3==0.3.5
-octodns==1.19.0
+# TODO: TEMPORARY - octodns 1.22.0 (with the new RDATA API from core PR #1452)
+# is unreleased. Pinning to the PR branch so CI can exercise this migration;
+# revert to a released `octodns==1.22.0` (regenerated via
+# ./script/update-requirements) once it ships.
+octodns @ git+https://github.com/octodns/octodns.git@refs/pull/1452/head
 packaging==26.2
 pathspec==1.1.1
 platformdirs==4.10.0

--- a/tests/test_additional_record_types.py
+++ b/tests/test_additional_record_types.py
@@ -64,6 +64,49 @@ class TestAdditionalRecordTypes(TestCase):
         self.assertIn('TLSA', types)
         self.assertIn('PTR', types)
 
+    def test_populate_ptr_multivalue(self):
+        # Prior to the RDATA API migration, _data_for_PTR only looked at
+        # records[0], so a PTR name with more than one value silently lost
+        # everything past the first. Record.from_rrsets() groups all values
+        # for a name/type before handing them to PtrRecord (a ValuesMixin),
+        # so this is now a genuine multi-value record.
+        provider = HetznerProvider('test', 'token')
+        provider._client.zone_get = Mock(
+            return_value={'id': 'unit.tests', 'name': 'unit.tests', 'ttl': 3600}
+        )
+        provider._client.zone_records_get = Mock(
+            return_value=[
+                {
+                    'type': 'PTR',
+                    'id': 'p1',
+                    'created': '',
+                    'modified': '',
+                    'zone_id': 'unit.tests',
+                    'name': 'ptr',
+                    'value': 'one.unit.tests.',
+                    'ttl': 300,
+                },
+                {
+                    'type': 'PTR',
+                    'id': 'p2',
+                    'created': '',
+                    'modified': '',
+                    'zone_id': 'unit.tests',
+                    'name': 'ptr',
+                    'value': 'two.unit.tests.',
+                    'ttl': 300,
+                },
+            ]
+        )
+
+        zone = Zone('unit.tests.', [])
+        provider.populate(zone)
+
+        (record,) = [r for r in zone.records if r._type == 'PTR']
+        self.assertEqual(
+            ['one.unit.tests.', 'two.unit.tests.'], sorted(record.values)
+        )
+
     def test_apply_ds_tlsa_ptr(self):
         provider = HetznerProvider('test', 'token', strict_supports=False)
         provider._client.zone_get = Mock(

--- a/tests/test_octodns_provider_hetzner.py
+++ b/tests/test_octodns_provider_hetzner.py
@@ -469,6 +469,70 @@ class TestHetznerProvider(TestCase):
             any_order=True,
         )
 
+    def test_populate_txt_raw_text(self):
+        # Hetzner's dnsapi returns TXT as raw provider text, not RDATA
+        # presentation format. A naive migration to Record.from_rrsets()
+        # would run these through TxtValue.from_rdata_text(), which treats
+        # an unquoted ';' as a master-file comment (silently truncating
+        # values) and raises on unquoted values over 255 characters.
+        # normalize_raw_text() must be used instead, preserving the full
+        # value and the pre-existing ';' -> '\;' escaping.
+        provider = HetznerProvider('test', 'token')
+        provider._client.zone_get = Mock(
+            return_value={'id': 'unit.tests', 'name': 'unit.tests', 'ttl': 3600}
+        )
+        long_value = 'a' * 300
+        provider._client.zone_records_get = Mock(
+            return_value=[
+                {
+                    'type': 'TXT',
+                    'id': 't1',
+                    'created': '',
+                    'modified': '',
+                    'zone_id': 'unit.tests',
+                    'name': 'txt',
+                    'value': long_value,
+                    'ttl': 600,
+                },
+                {
+                    'type': 'TXT',
+                    'id': 't2',
+                    'created': '',
+                    'modified': '',
+                    'zone_id': 'unit.tests',
+                    'name': 'txt',
+                    'value': 'v=DKIM1;k=rsa',
+                    'ttl': 600,
+                },
+            ]
+        )
+
+        zone = Zone('unit.tests.', [])
+        provider.populate(zone)
+
+        (record,) = [r for r in zone.records if r._type == 'TXT']
+        self.assertEqual(
+            sorted([long_value, 'v=DKIM1\\;k=rsa']), sorted(record.values)
+        )
+
+    def test_params_for_txt_backend_specific(self):
+        # dnsapi wants raw, unquoted text (and Hetzner's own re-quoting of
+        # that text is inconsistent, see
+        # ansible-collections/community.dns#48), while hcloud is RRSet-based
+        # and wants quoted, chunked RDATA presentation text. _params_for()
+        # must keep producing each backend's expected format.
+        dnsapi_provider = HetznerProvider('test', 'token')
+        zone = Zone('unit.tests.', [])
+        record = Record.new(
+            zone, 'txt', {'ttl': 600, 'type': 'TXT', 'value': 'v=DKIM1\\;k=rsa'}
+        )
+        (params,) = list(dnsapi_provider._params_for(record))
+        self.assertEqual('v=DKIM1;k=rsa', params['value'])
+
+        hcloud_provider = HetznerProvider('test', 'token', backend='hcloud')
+        (params,) = list(hcloud_provider._params_for(record))
+        self.assertEqual('"v=DKIM1;k=rsa"', params['value'])
+
     def test_list_zones(self):
         provider = HetznerProvider('test', 'token')
 


### PR DESCRIPTION
## Summary

- Migrates from octoDNS's inconsistent `Rr`/`record.rrs`/`parse_rdata_text`/`value.rdata_text` API to the new spec-compliant `Rrset`/`Record.from_rrsets()`/`from_rdata_text()`/`to_rdata_text()` API (core PR [octodns/octodns#1452](https://github.com/octodns/octodns/pull/1452), unreleased — will ship as `octodns==1.22.0`). Companion migration to [octodns-bind#112](https://github.com/octodns/octodns-bind/pull/112).
- Collapses the read path's eleven `_data_for_*` methods into one `_rdata_for()` normalizer + `Record.from_rrsets()`, and the write path's ten `_params_for_*` methods into one generic `_params_for()` built from `record.to_rrset()`. Net -151 lines in `octodns_hetzner/__init__.py`.
- **TXT keeps dedicated handling on both sides**, since Hetzner's dnsapi speaks raw provider text rather than RDATA presentation format:
  - *Read*: `from_rdata_text()` runs values through dnspython, which treats an unquoted `;` as a master-file comment — this would silently truncate values like DKIM keys (`v=DKIM1;k=rsa;...` → `v=DKIM1`) and raise on any unquoted value over 255 chars. `TxtValue.normalize_raw_text()` (public `octodns.record.TxtValue`) is used instead.
  - *Write*: Hetzner's API does accept quoted presentation text, but its re-quoting is inconsistent enough that [ansible-collections/community.dns#48](https://github.com/ansible-collections/community.dns/issues/48) settled on unquoted-by-default for this provider specifically, to avoid idempotency churn. `to_rdata_text()`'s `"` escaping is also not reversible on the way back in. So dnsapi TXT writes stay raw/unquoted via `TxtValue.to_raw_text()`; the hcloud backend (RRSet-native, already quoted) is unaffected and now goes through `to_rrset()` directly.
- **Bug fix**: multi-value PTR records previously only kept their first value (`_data_for_PTR` always indexed `records[0]`). Routing through `Record.from_rrsets()` fixes this for free.
- Raises the `octodns` floor to `>=1.22.0` and removes the blanket `ignore:.*DEPRECATED.*2.0` warning filter added in #71 — the full suite now passes with `filterwarnings = ['error']`, proving no legacy API calls remain.
- `requirements.txt` temporarily pins `octodns` to the PR #1452 branch so CI can exercise this before core releases; needs reverting to a released `octodns==1.22.0` via `./script/update-requirements` once that ships.

## Test plan

- [x] Full existing suite (50 tests) passes **unmodified** — the primary signal that read/write output is byte-identical to the pre-migration behavior.
- [x] Added 3 tests: multi-value PTR read (the bug fix), TXT raw-text round-trip (>255 chars + embedded `;`), and dnsapi-vs-hcloud TXT write divergence.
- [x] 100% coverage maintained (`./script/coverage`).
- [x] `./script/lint` / `./script/format --check` clean.
- [x] `./script/changelog check` clean.
- [x] Verified zero `DeprecationWarning`s by running the suite with `filterwarnings = ['error']` and no ignore.
